### PR TITLE
hacks hacks hacks

### DIFF
--- a/src/xqemurun.py
+++ b/src/xqemurun.py
@@ -241,7 +241,7 @@ class XQEMURun():
 
 		if self.config_runtime.getKey("core", "gdb") == "yes":
 			print("gdb debug: enabled")
-			qemu_command += [ "-s", "-S" ]
+			qemu_command += [ "-s" ] # Pause: [ "-S" ]
 		else:
 			print("gdb debug: disabled")
 
@@ -315,7 +315,7 @@ class XQEMURun():
 
 		qemu_media_arg = "index=1,media=cdrom"
 
-		media_path = self.config_runtime.getKey(machine, "media")
+		media_path = self.config_runtime.getKey("sys", "media")
 		if media_path and media_path not in self.disabled:
 			print("media iso: " + media_path)
 			qemu_media_arg += ",file=" + media_path
@@ -343,7 +343,7 @@ class XQEMURun():
 			print("usb hub: " + usb_hub_option)
 			usb_product_id = usb_hub_option[8:13]
 			usb_vendor_id = usb_hub_option[14:19]
-			qemu_usb_hub_device_arg = "usb-host,bus=usb-bus.0,port=3,product_id=" + usb_product_id + ",vendorid=" + usb_vendor_id
+			qemu_usb_hub_device_arg = "usb-host,bus=usb-bus.0,port=3,productid=" + usb_product_id + ",vendorid=" + usb_vendor_id
 			qemu_command += [ "-usb", "-device", qemu_usb_hub_device_arg ]
 
 		if usb_hub_option == "emulated":
@@ -357,15 +357,30 @@ class XQEMURun():
 
 				if usb_pad_option == "keyboard":
 					print("usb " + pad + ": keyboard")
-					qemu_usb_pad_device_arg = "usb-xbox-gamepad,bus=usb-bus.0,port=" + pad_dict[pad] + ".2"
+					qemu_usb_pad_device_arg = "usb-xbox-gamepad,port=3" #,port=" + pad_dict[pad] + ".2"
 					qemu_command += [ "-device", qemu_usb_pad_device_arg ]
 
 				elif usb_pad_option[0:8] == "forward:":
 					print("usb " + pad + ": " + usb_pad_option)
 					usb_product_id = usb_hub_option[8:13]
 					usb_vendor_id = usb_hub_option[14:19]
-					qemu_usb_pad_device_arg = "usb-host,bus=usb-bus.0,port=3.2,product_id=" + usb_product_id + ",vendorid=" + usb_vendor_id
+					qemu_usb_pad_device_arg = "usb-host,bus=usb-bus.0,port=3.2,productid=" + usb_product_id + ",vendorid=" + usb_vendor_id
 					qemu_command += [ "-usb", "-device", qemu_usb_hub_device_arg ]
+
+		qemu_command += [ "-display", "gtk" ]
+		#qemu_command += [ "-display", "sdl" ]
+
+		if False:
+			qemu_command += [ "-net", "bridge,helper=/usr/lib/qemu/qemu-bridge-helper,br=bridge0" ]
+			qemu_command += [ "-net", "nic,model=nvnet" ]
+		else:
+			qemu_command += [ "-redir", "tcp:9269::9269" ]
+			qemu_command += [ "-redir", "tcp:8731::731" ]
+			#qemu_command += [ "-redir", "tcp:20::20" ]
+			#qemu_command += [ "-redir", "tcp:80::80" ]
+			qemu_command += [ "-redir", "tcp:4097::4097" ]
+			#qemu_command += [ "-smb", "/tmp/xqemu" ]
+
 
 		print("qemu command line : " + str(qemu_command))
 


### PR DESCRIPTION
@illwieckz

Basically hacked together to make it more useful for development.

Overall I'd recommend to go all-in on making this a tool aimed at developers.


We have xqemu-manager for users, so ideally we'd have a seperate tool for developers.
Such a tool must make it easy to attach gdb (provide examples in README too), easy to run apitrace, auto-build / make qemu on run (or provide examples in README), get rid of convience bloat, make it easy to switch different arguments.

Here's the tool I used previously:

```bash
#!/bin/bash



hdd=xbox-5960.qcow2 
hdd="/home/fox/Data/Projects/xqemu-tools/roms/xbox_harddisk.qcow2"
#bios="/home/fox/Data/Projects/xqemu-data/<redacted>.bin"
bios="/home/fox/Data/Projects/xqemu-data/<redacted>.bin"
#bios="/home/fox/Data/Projects/xqemu-data/3944_1M.bin"
#bios="/home/fox/Data/Projects/emuwell/image/emuwell_1024.bin"
bootrom="/home/fox/Data/Projects/xqemu-data/mcpx_1.0.bin"

dvd_iso_tmp="/tmp/xqemu-dvd"
qemu="/home/fox/Data/Projects/xqemu-espes"


set -u
reset && clear

dvd="$1"
shift
dvd_filename="$(basename "$dvd")"
dvd_extension="${dvd_filename##*.}"
dvd_path="$(dirname "$dvd")/"
#dvd_filename="${filename%.*}"

echo "$dvd_extension"
#FIXME: Check if dvd_extension is a path
if [ "$dvd_extension" == "iso" ]; then # FIXME: also enable xiso
  echo "Loading iso"
elif [ "$dvd_extension" == "xbe" ]; then
  rm -r "$dvd_iso_tmp/"
  mkdir -p "$dvd_iso_tmp/"
  echo "Attempting to run XBE file! <$dvd>"
  # FIXME: Check if dvd_tmp was set properly..
  echo "Got temp dir <$dvd_iso_tmp/>"
  cp -sR "$dvd_path"* "$dvd_iso_tmp/"
  ls "$dvd_iso_tmp/" -l
  dvd_xbe="${dvd_iso_tmp}/default.xbe"
  echo "Linking default.xbe!"
  #rm -f "$dvd_xbe"
  #ln -s "$dvd_filename" "$dvd_xbe" 
  dvd="${dvd_iso_tmp}.iso"
  extract-xiso -m -c "$dvd_iso_tmp/" "$dvd"
#  exit
else
  echo "Unsupported DVD!"
fi

usb_gamepad=0
kvm=0
gl_sw=0
gl_debug=0
apitrace=0

while [ $# -ne 0 ]; do
  option="$1"
  shift
echo "Parsing $option, $#"
  if [ "$option" == "usb" ]; then
    usb_gamepad=1
  elif [ "$option" == "apitrace" ]; then
    apitrace=1
  elif [ "$option" == "kvm" ]; then
    kvm=1
  elif [ "$option" == "gl-sw" ]; then
    gl_sw=1
  elif [ "$option" == "gl-debug" ]; then
    gl_debug=1
  elif [ "$option" == "-" ]; then
    break
  else
    echo "Unknown Option <$option>"
    exit 1
  fi
done

if [ $gl_debug -ne 0 ]; then
  export LIBGL_DEBUG=verbose
  export MESA_DEBUG=1
  export EGL_LOG_LEVEL=debug
fi

if [ $gl_sw -ne 0 ]; then
  export LIBGL_ALWAYS_SOFTWARE=1
fi

# Using espes version, QEMU 1.7 [broken usb-bus.1], Found using mashed
if [ $usb_gamepad -eq 0 ]; then
  #usb="-usb -device usb-hub,bus=usb-bus.0,port=4 -device usb-xbox-gamepad,bus=usb-bus.0,port=4.2" #P2
  cli_usb="-usb -device usb-hub,bus=usb-bus.0,port=3 -device usb-xbox-gamepad,bus=usb-bus.0,port=3.2" #P1
  #usb="-usb -device usb-hub,bus=usb-bus.0,port=2 -device usb-xbox-gamepad,bus=usb-bus.0,port=2.2" #P4
  #usb="-usb -device usb-hub,bus=usb-bus.0,port=1 -device usb-xbox-gamepad,bus=usb-bus.0,port=1.2" #P3

  # ALPHA STUFF LOLZ
  #cli_usb="-usb -device usb-hub,bus=usb-bus.0,port=3 -device usb-xbox-gamepad-sdl,device='Microsoft X-Box 360 pad',index=0,bus=usb-bus.0,port=3.2" #P1

else
  cli_usb="-usb -device usb-hub,bus=usb-bus.0,port=3 -device usb-host,vendorid=0x45e,productid=0x289,bus=usb-bus.0,port=3.2" #P1
#  usb="-usb -device usb-host,bus=usb-bus.0,port=3,vendorid=0x45e,productid=0x288" #P1
  echo "Using xbox pad!"
fi

if [ $kvm -ne 0 ]; then
  cli_kvm="-enable-kvm"
else
#  cli_kvm="-icount 0"
  cli_kvm=""
fi

if [ $apitrace -ne 0 ]; then
  cli_apitrace="apitrace trace"
else
  cli_apitrace=""
fi

# SIGUSR1 and SIGUSR2 are used for threading / fibers / ..
# SIGPIPE can occur while a network connection breaks when data is still in buffers
cli_gdb=""
cli_gdb="gdb -ex 'handle SIGUSR1 nostop noprint pass' -ex 'handle SIGUSR2 nostop noprint pass' -ex 'handle SIGPIPE nostop noprint pass' --args"

# Disable vsync
export vblank_mode=0

cli_shortanim=",short_animation"

#FIXME: Can't get this to work properly on my HD4000
cli_perf="" # "sudo perf record -g -e i915:i915_gem_request_wait_begin -c 1"

#network="-redir tcp:9269::9269 -redir tcp:20::20 -redir tcp:80::80 -redir tcp:4097::4097 -redir tcp:21::21"
network=""

cli_xdk="-device lpc47m157 -serial unix:/tmp/xserial,server"

echo ""
echo ""
pushd "$qemu" > /dev/null
#"-sdl"
make && eval "$cli_perf $cli_apitrace $cli_gdb ./xbox-softmmu/qemu-system-xbox $network -cpu pentium3 -machine xbox,bootrom=\"$bootrom\",kernel_irqchip=off$cli_shortanim -m 128 -drive file=\"$hdd\",index=0,media=disk,locked=on -drive index=1,media=cdrom,file=\"$dvd\" -bios \"$bios\" $cli_usb $cli_kvm $cli_xdk" $*

popd
```

I'd just go in and comment in / out rarely used stuff. but the command line interface exposed most important options with short, easy to remember names [in any order] and allows custom options to be added near the end.
I wish xqemurun could do similar things (also see my existing issues).

(also note that this can mount an existing XISO, a folder [generates XISO], or choose any xbe in folder [and then generates XISO with that file as default.xbe])